### PR TITLE
override register and password forms

### DIFF
--- a/auth0.routing.yml
+++ b/auth0.routing.yml
@@ -14,7 +14,7 @@ auth0.legacy_login:
     _form: '\Drupal\user\Form\UserLoginForm'
     _title: 'Log in'
   requirements:
-    _access: 'TRUE'
+    _user_is_logged_in: 'FALSE'
   options:
     _maintenance_access: TRUE
 
@@ -30,7 +30,45 @@ auth0.logout:
   defaults:
     _controller: '\Drupal\auth0\Controller\AuthController::logout'
   requirements:
+    _user_is_logged_in: 'TRUE'
+
+auth0.password:
+  path: '/user/password'
+  defaults:
+    _controller: '\Drupal\auth0\Controller\AuthController::login'
+    _title: 'Reset your password'
+  requirements:
     _access: 'TRUE'
+  options:
+    _maintenance_access: TRUE
+
+auth0.legacy_password:
+  path: '/user/password/legacy'
+  defaults:
+    _form: '\Drupal\user\Form\UserPasswordForm'
+    _title: 'Reset your password'
+  requirements:
+    _access: 'TRUE'
+  options:
+    _maintenance_access: TRUE
+
+auth0.register:
+  path: '/user/register'
+  defaults:
+    _controller: '\Drupal\auth0\Controller\AuthController::login'
+    _title: 'Create new account'
+  requirements:
+    _access: 'TRUE'
+  options:
+    _maintenance_access: TRUE
+
+auth0.legacy_register:
+  path: '/user/register/legacy'
+  defaults:
+    _entity_form: 'user.register'
+    _title: 'Create new account'
+  requirements:
+    _access_user_register: 'TRUE'
 
 auth0.verify_email:
   path: '/auth0/verify_email'

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -288,7 +288,7 @@ class AuthController extends ControllerBase {
   }
 
   /**
-   * Handles the login page override.
+   * Handles the logout page override.
    *
    * @return \Drupal\Core\Routing\TrustedRedirectResponse
    *   The response after logout.
@@ -857,18 +857,18 @@ class AuthController extends ControllerBase {
       $user_roles = $user->getRoles();
 
       $new_user_roles = array_merge(array_diff($user_roles, $not_granted), $roles_granted);
-      
+
       $roles_to_add = array_diff($new_user_roles, $user_roles);
       $roles_to_remove = array_diff($user_roles, $new_user_roles);
-      
+
       if (empty($roles_to_add) && empty($roles_to_remove)) {
           $this->auth0Logger->notice('no changes to roles detected');
           return;
-      } 
-         
+      }
+
       $this->auth0Logger->notice('changes to roles detected');
       $edit['roles'] = $new_user_roles;
-      
+
       foreach ($roles_to_add as $new_role) {
           $user->addRole($new_role);
       }
@@ -1029,7 +1029,7 @@ class AuthController extends ControllerBase {
    *
    * @throws \Auth0\SDK\Exception\CoreException
    *   Exception thrown when validating email.
-   * 
+   *
    * @deprecated v8.x-2.4 - the legacy send_verification_email endpoint itself is being deprecated and should no longer be called.
    */
   // phpcs:ignore


### PR DESCRIPTION
### Changes

Redirect the /user/register and /user/password routes in Drupal to the Auth0 login form.

Provide new routes at /user/register/legacy and /user/password/legacy to access the default forms.

### References

https://github.com/auth0-community/auth0-drupal/issues/166

### Testing

After applying this change, the following routes will go to Auth0:
- /user/login
- /user/register
- /user/password

The following routes will go to the legacy Drupal forms:
- /user/login/legacy
- /user/register/legacy
- /user/password/legacy

### Checklist

* [ Y ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ Y ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ Y ] I ran the PHPCS Drupal coding standards:

```bash
# Ran from the Drupal root
$ vendor/bin/phpcs modules/auth0/src --standard=Drupal
```
