### PR TITLE
Add support for passing in extra parameters to auth0 authorization URL.

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -257,7 +257,9 @@ class AuthController extends ControllerBase {
 
     // If supporting SSO, redirect to the hosted login page for authorization.
     if ($this->redirectForSso) {
-      return new TrustedRedirectResponse($this->buildAuthorizeUrl(NULL, $returnTo));
+      $extra_params = $request->query->all();
+
+      return new TrustedRedirectResponse($this->buildAuthorizeUrl(NULL, $returnTo, $extra_params));
     }
 
     /* Not doing SSO, so show login page */
@@ -342,11 +344,13 @@ class AuthController extends ControllerBase {
    *   If prompt=none should be passed, false if not.
    * @param string $returnTo
    *   Local path|null if null, use default of /user.
+   * @param array $extra_params
+   *   An optional array of extra parameters to pass to the authorization URL.
    *
    * @return string
    *   The URL to redirect to for authorization.
    */
-  protected function buildAuthorizeUrl($prompt, $returnTo = NULL) {
+  protected function buildAuthorizeUrl($prompt, $returnTo = NULL, array $extra_params = []) {
     global $base_root;
 
     $auth0Api = new Authentication($this->helper->getAuthDomain(), $this->clientId);
@@ -364,6 +368,10 @@ class AuthController extends ControllerBase {
 
     if ($prompt) {
       $additional_params['prompt'] = $prompt;
+    }
+
+    foreach ($extra_params as $param => $value) {
+      $additional_params[$param] = $value;
     }
 
     return $auth0Api->get_authorize_link($response_type, $redirect_uri, $connection, $state, $additional_params);


### PR DESCRIPTION
### Changes

Pass in extra parameters to authorization URL when using "Universal Login".

### References

https://github.com/auth0-community/auth0-drupal/issues/170

### Testing

#### Auth0

1. In your Auth0 dashboard, follow the [documentation](https://community.auth0.com/t/how-do-i-redirect-users-directly-to-the-hosted-signup-page/42520) to update your 'Classic Universal Login' page to utilize the 'initialScreen' option.

#### Drupal

1. From the Advanced settings page (admin/config/auth0/advanced), check the 'Universal Login Page' checkbox and then save your changes.
2. As an anonymous user, pass in an extra parameter to the login link according to your Auth0 changes (e.g. /user/login?action=signup)
3. You should be redirected to your Auth0 universal login page with the parameters you passed visible in the page's URL.
4. If you followed the example from Auth0, then the 'Sign Up' tab should be automatically selected instead of the 'Log In' tab.
5. Sign up or register as per normal, you should then be redirect back to your Drupal site and logged in.

### Checklist

* [ Y ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ Y ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ Y ] I ran the PHPCS Drupal coding standards:

```bash
# Ran from the Drupal root
$ vendor/bin/phpcs modules/auth0/src --standard=Drupal
```
